### PR TITLE
Use the new _zsh_highlighter_add_highlight function

### DIFF
--- a/url/url-highlighter.zsh
+++ b/url/url-highlighter.zsh
@@ -51,7 +51,7 @@ _zsh_highlight_url_highlighter()
   done
 
   local match_count=$#matches
-  local i
+  local i style
   
   for ((i=1; $i <= $match_count; i++)); do
     match=$matches[$i]
@@ -67,10 +67,11 @@ _zsh_highlight_url_highlighter()
       _ZSH_HIGHLIGHT_URL_HIGHLIGHTER_CACHE[$match]=$status_code
     fi
     if [[ "$status_code" == "200" ]]; then
-      region_highlight+=("$matches_starts[$i] $matches_ends[$i] ${ZSH_HIGHLIGHT_STYLES[url-good]}")
+      style=url-good
     else
-      region_highlight+=("$matches_starts[$i] $matches_ends[$i] ${ZSH_HIGHLIGHT_STYLES[url-bad]}")
+      style=url-bad
     fi
+    _zsh_highlight_add_highlight $matches_starts[i] $matches_ends[i] $style
   done
 }
 


### PR DESCRIPTION
zsh-syntax-highlighting master has `_zsh_highlight_add_highlight`, so highlighters should no longer interact with region_highlight directly. You may wish to wait on merging this since no upstream release has the function yet.
